### PR TITLE
Fix character selection display with more than 2 characters

### DIFF
--- a/game/data/menu_char_select/screen.asm
+++ b/game/data/menu_char_select/screen.asm
@@ -4,7 +4,7 @@ char_selection_palette:
 ; Sprites
 .byt $0f,$0f,$3d,$0f, $0f,$00,$00,$00, $0f,$0f,$3d,$0f, $0f,$00,$00,$00
 
-#define A $4c
+#define A $44+4*CHARACTERS_NUMBER
 #define B A+48
 char_selection_nametable:
 .byt $00,$84

--- a/game/logic/game_states/character_selection_screen/character_selection_screen.c
+++ b/game/logic/game_states/character_selection_screen/character_selection_screen.c
@@ -429,7 +429,7 @@ static void tick_bg_task(struct BgTaskState* task) {
 			builders_anim->y = builder_anims_start_pos[task->player].y;
 
 			// Compute ppu_addr/prg_addr at the begining of the tileset
-			task->ppu_addr = 0x1000 + 16 * (tileset_menu_char_select + 2 * 4 + task->player * 48);
+			task->ppu_addr = 0x1000 + 16 * (tileset_menu_char_select + (uint16_t)(&CHARACTERS_NUMBER) * 4 + task->player * 48);
 			if (config_requested_player_a_character[task->player] < (uint16_t)&CHARACTERS_NUMBER) {
 				// Normal character, get its large illustration address
 				task->prg_addr = (uint8_t const*)wrap_character_selection_get_char_property(
@@ -803,7 +803,7 @@ void init_character_selection_screen_extra() {
 	*PPUDATA = TILE_DICE_SE;
 
 	// Init empty statues tiles
-	uint16_t const ppu_tiles_statues_addr = 0x1000 + 16 * (tileset_menu_char_select + 4*2);
+	uint16_t const ppu_tiles_statues_addr = 0x1000 + 16 * (tileset_menu_char_select + 4*(uint16_t)(&CHARACTERS_NUMBER));
 	*PPUSTATUS;
 	*PPUADDR = u16_msb(ppu_tiles_statues_addr);
 	*PPUADDR = u16_lsb(ppu_tiles_statues_addr);


### PR DESCRIPTION
Some parts of the code hardcoded the number of characters, leading to
incorrectly displayed "small" illustrations starting from the 3rd
character.


Below is a screenshot showing the issue: the "small illustration" of the 3rd character shows the top of Sinbad's right fist (the one from the statue), instead of the actual small illustration. It actually shows the first tiles of player 1's statue, and is updated together with it.
![stb-charselect-bug](https://user-images.githubusercontent.com/666114/110379945-c1fc9c80-8057-11eb-94c2-e577e4092093.png)
