### PR TITLE
documentation: Fix formatting

### DIFF
--- a/documentation/characters.rst
+++ b/documentation/characters.rst
@@ -5,8 +5,8 @@ The characters editor can be found here: https://benoitryder.github.io/stb-mod-e
 
 Source code may be at two locations, choose the most up to date:
 
- * https://github.com/benoitryder/stb-mod-editor
- * https://github.com/sgadrat/stb-mod-editor
+* https://github.com/benoitryder/stb-mod-editor
+* https://github.com/sgadrat/stb-mod-editor
 
 Characters animations
 =====================
@@ -24,10 +24,10 @@ Special case: the idle animation should not have more than 3 sprites per scanlin
 Constraints on netload routines
 ===============================
 
- * ``A``: output: Can be modified
- * ``X``: output: Can be modified, input: Contains player number
- * ``Y``: output: Must be incremented by character's payload size, input: offset of character's data in current message
- * ``player_number``: output: Cannot be modified, input: Contains player number
+* ``A``: output: Can be modified
+* ``X``: output: Can be modified, input: Contains player number
+* ``Y``: output: Must be incremented by character's payload size, input: offset of character's data in current message
+* ``player_number``: output: Cannot be modified, input: Contains player number
 
 Constraints on tick routines
 ============================
@@ -35,35 +35,35 @@ Constraints on tick routines
 Registers
 ---------
 
- * ``A``: output: Can be modified
- * ``X``: output: Cannot be modified, input: Contains player number
- * ``Y``: output: Can be modified
- * ``player_number``: output: Can be modified, input: not ensured to be set
- * ``tmpfields``: Can be modified
- * ``extra_tmpfields``: To be checked
+* ``A``: output: Can be modified
+* ``X``: output: Cannot be modified, input: Contains player number
+* ``Y``: output: Can be modified
+* ``player_number``: output: Can be modified, input: not ensured to be set
+* ``tmpfields``: Can be modified
+* ``extra_tmpfields``: To be checked
 
 Constraints on start routines
 =============================
 
 Tick routines constraints generally apply, as start routines are often called from a tick routine
 
- * ``A``: output: Can be modified
- * ``X``: output: cannot be modified
- * ``Y``: output: Can be modified
- * ``player_number``: output: to be checked, input: not ensured to be set
- * ``tmpfields``: Can be modified
- * ``tmpfield15``: Used by aerial input code, aerial attacks should not modify it (or {char_name}_check_aerial_inputs should be fixed to use the stack/extra tmpfields)
- * ``extra_tmpfields``: To be checked
+* ``A``: output: Can be modified
+* ``X``: output: cannot be modified
+* ``Y``: output: Can be modified
+* ``player_number``: output: to be checked, input: not ensured to be set
+* ``tmpfields``: Can be modified
+* ``tmpfield15``: Used by aerial input code, aerial attacks should not modify it (or {char_name}_check_aerial_inputs should be fixed to use the stack/extra tmpfields)
+* ``extra_tmpfields``: To be checked
 
 Constraints on input routines
 =============================
 
- * ``A``: output: Can be modified
- * ``X``: output: Cannot be modified, input: Contains player number
- * ``Y``: output: Can be modified
- * ``player_number``: output: Can be modified, input: not ensured to be set
- * ``tmpfields``: Can be modified
- * ``extra_tmpfields``: To be checked
+* ``A``: output: Can be modified
+* ``X``: output: Cannot be modified, input: Contains player number
+* ``Y``: output: Can be modified
+* ``player_number``: output: Can be modified, input: not ensured to be set
+* ``tmpfields``: Can be modified
+* ``extra_tmpfields``: To be checked
 
 Constraints on onhurt routines
 ==============================
@@ -71,16 +71,16 @@ Constraints on onhurt routines
 Registers
 ---------
 
- * ``A``: output: Can be modified, input: garbage
- * ``X``: output: Can be modified, input: player number
- * ``Y``: output: Can be modified, input: garbage
- * ``player_number``: output: to be checked if can be modified, input: to be checked if ensured to be good
- * ``tmpfield10``: output: cannot be modified, input: Player number of the striker
- * ``tmpfield11``: output: cannot be modified, input: Player number of the stroke (equal to register X)
- * ``tmpfield12``: output: can be modified, input: default hurt routine lsb
- * ``tmpfield13``: output: can be modified, input: default hurt routine msb
- * ``tmpfield14``: output: can be modified, input: default hurt routine bank
- * ``other tmpfields``: output: can be modified, input garbage
+* ``A``: output: Can be modified, input: garbage
+* ``X``: output: Can be modified, input: player number
+* ``Y``: output: Can be modified, input: garbage
+* ``player_number``: output: to be checked if can be modified, input: to be checked if ensured to be good
+* ``tmpfield10``: output: cannot be modified, input: Player number of the striker
+* ``tmpfield11``: output: cannot be modified, input: Player number of the stroke (equal to register X)
+* ``tmpfield12``: output: can be modified, input: default hurt routine lsb
+* ``tmpfield13``: output: can be modified, input: default hurt routine msb
+* ``tmpfield14``: output: can be modified, input: default hurt routine bank
+* ``other tmpfields``: output: can be modified, input garbage
 
 ``default_hurt_player`` routine is a helper to call the default hurt routine from fixed bank.
 
@@ -95,18 +95,18 @@ Constraints on offground routines
 Constraints on global tick routines
 ===================================
 
- * ``A``: output: Can be modified, input: garbage
- * ``X``: output: Cannot be modified, input: player number
- * ``Y``: output: Can be modified, input: garbage
- * ``player_number``: output: can be modified, input: garbage
+* ``A``: output: Can be modified, input: garbage
+* ``X``: output: Cannot be modified, input: player number
+* ``Y``: output: Can be modified, input: garbage
+* ``player_number``: output: can be modified, input: garbage
 
 Constraints on projectile hit routines
 ======================================
 
- * ``A``: output: Can be modified, input: garbage
- * ``X``: output: Cannot be modified, input: projectile owner's player number
- * ``Y``: output: Can be modified, input: hitbox type
- * ``player_number``: output: can be modified, input: garbage
+* ``A``: output: Can be modified, input: garbage
+* ``X``: output: Cannot be modified, input: projectile owner's player number
+* ``Y``: output: Can be modified, input: hitbox type
+* ``player_number``: output: can be modified, input: garbage
 
 Custom hitboxes
 ===============
@@ -118,16 +118,16 @@ In some case, you may need more flexibility and here comes the custom hitbox. It
 Constraints on the callback
 ---------------------------
 
- * ``A``: output: Can be modified, input: Garbage
- * ``X``: output: Can be modified, input: Player number
- * ``Y``: output: Can be modified, input: Type of the collided object (``HITBOX`` or ``HURTBOX`` defined in global constants)
- * ``player_number``: output: Can be modified, input: Not ensured to be set
- * ``tmpfields``: output: can be modified, input: Garbage
+* ``A``: output: Can be modified, input: Garbage
+* ``X``: output: Can be modified, input: Player number
+* ``Y``: output: Can be modified, input: Type of the collided object (``HITBOX`` or ``HURTBOX`` defined in global constants)
+* ``player_number``: output: Can be modified, input: Not ensured to be set
+* ``tmpfields``: output: can be modified, input: Garbage
 
-When ``Y`` is set to ``HITBOX`` the callback is responsible for consequences of the collision::
+When ``Y`` is set to ``HITBOX`` the callback is responsible for consequences of the collision:
 
- * On the character it controls,
- * On the opponent if the opponent's hitbox is direct.
+* On the character it controls,
+* On the opponent if the opponent's hitbox is direct.
 
 Direct hitboxes will not apply parry to their opponent when colliding to a custom hitbox.
 
@@ -136,33 +136,33 @@ Note that if both hitboxes are custom, only avatar A's callback will be called. 
 Memory allocation
 =================
 
- * ``$00`` -> ``$69``: Avatar state
- * ``$0480`` -> ``$04ff``: Avatar objects
- * ``$0600`` -> ``$0641``: Avatar projectiles
+* ``$00`` -> ``$69``: Avatar state
+* ``$0480`` -> ``$04ff``: Avatar objects
+* ``$0600`` -> ``$0641``: Avatar projectiles
 
 Avatar state
 ------------
 
 The engine maintains all avatars state variables in an interleaved table in zero-page from $0000 to $0069. These variables are named ``player_a_*`` and ``player_b_*``, and often accessed by setting player's number in register X and using it as an index from ``player_a_xxx`` variant of the variable.
 
-Most of these variables have specific meaning for the engine and are to be updated accordingly by character's code. Some are free to use for character-specific logic::
+Most of these variables have specific meaning for the engine and are to be updated accordingly by character's code. Some are free to use for character-specific logic:
 
- - player_x_state_fieldN: automatically restored by netcode, action templates may use it.
- - player_x_state_extraN: character's netcode is responsible of it, action templates do not use it.
+* ``player_x_state_fieldN``: automatically restored by netcode, action templates may use it.
+* ``player_x_state_extraN``: character's netcode is responsible of it, action templates do not use it.
 
 Avatar objects
 --------------
 
 Character code can also manipulate 64 bytes of linear memory. These regions are named ``player_a_objects`` and ``player_b_object``, and are not interleaved. The engine interprets data in these regions as a list of avatar-independent "ojects" of different types.
 
-Object types::
+Object types:
 
- * STAGE_ELEMENT_END
- * STAGE_ELEMENT_PLATFORM
- * STAGE_ELEMENT_SMOOTH_PLATFORM
- * STAGE_ELEMENT_OOS_PLATFORM
- * STAGE_ELEMENT_OOS_SMOOTH_PLATFORM
- * STAGE_ELEMENT_BUMPER
+* STAGE_ELEMENT_END
+* STAGE_ELEMENT_PLATFORM
+* STAGE_ELEMENT_SMOOTH_PLATFORM
+* STAGE_ELEMENT_OOS_PLATFORM
+* STAGE_ELEMENT_OOS_SMOOTH_PLATFORM
+* STAGE_ELEMENT_BUMPER
 
 The engine does not read data after the byte indentifying a STAGE_ELEMENT_END. The memory after this byte can be freely used by character code.
 
@@ -171,10 +171,10 @@ Avatar projectiles
 
 Character code can manipulate some projectiles per avatar. These are stored in variables ``player_a_projectiles_N_xxx`` and ``player_b_projectile_N_xxx``, and are interleaved between players. Where ``N`` is the projectile number.
 
-Useful constants::
+Useful constants:
 
- * PROJECTILE_FLAGS_DEACTIVATED
- * PROJECTILE_DATA_SIZE
- * NB_PROJECTILES_PER_PLAYER
+* PROJECTILE_FLAGS_DEACTIVATED
+* PROJECTILE_DATA_SIZE
+* NB_PROJECTILES_PER_PLAYER
 
 Projectiles are zero-initialized at the begining of the game, then never write again by the engine. Maintaining it and trasfering it in netcode's state is the responsibility of character's implementation.

--- a/documentation/game_loop.rst
+++ b/documentation/game_loop.rst
@@ -9,6 +9,7 @@ Game initialization
 ###################
 
 TODO:
+
 - What's needed to correctly init `game` state
 	- game modes, link to game_modes.rst
 	- characters

--- a/documentation/game_modes.rst
+++ b/documentation/game_modes.rst
@@ -8,10 +8,10 @@ Game modes are a series of hooks that can modify ingame state's behavior.
 Currently implemented game modes
 ================================
 
- * ``local``: Handles the pause and the AI.
- * ``online``: Handles netcode.
- * ``arcade``: Handles the pause, the AI, break the target, and run to exit.
- * ``server``: Like ``local``, without pause nor AI. Used to simulate an ``online`` game server-side.
+* ``local``: Handles the pause and the AI.
+* ``online``: Handles netcode.
+* ``arcade``: Handles the pause, the AI, break the target, and run to exit.
+* ``server``: Like ``local``, without pause nor AI. Used to simulate an ``online`` game server-side.
 
 Memory allocation
 =================
@@ -23,11 +23,11 @@ Init hook
 
 Called after the generic initialization, but before stage initialization.
 
-The initialization sequence is::
+The initialization sequence is:
 
- * Generic initialization
- * Game mode initialization
- * Stage initialization
+* Generic initialization
+* Game mode initialization
+* Stage initialization
 
 It means that game mode can modify what as been done by generic code, and the stage can further customize it. It goes from the most generic to the more specific.
 
@@ -36,9 +36,9 @@ Pre update hook
 
 Called before anything else in the game tick.
 
-Output::
+Output:
 
- * `Carry flag``: if set when returning from the hook, the game tick will be skipped
+* ``Carry flag``: if set when returning from the hook, the game tick will be skipped
 
 Gameover hook
 =============

--- a/documentation/nametable_buffers.rst
+++ b/documentation/nametable_buffers.rst
@@ -4,12 +4,12 @@ Memory usage per component
 Engine
 ------
 
-Summary::
+Summary:
 
 * Each frame: 14 bytes (unprotected)
 * Peak: 68 bytes (unprotected)
 
-Detail::
+Detail:
 
 * Each frame: 7 bytes for player A's palette
 * Each frame: 7 bytes for player B's palette
@@ -23,12 +23,12 @@ Stages
 
 Stages have to handle fadeout and screen restore. They mostly share the same code, so here is the stage's impact if not specified.
 
-Summary::
+Summary:
 
 * Each frame: 0 byte
 * Peak: 36 bytes (protected) + 0 byte (unprotected)
 
-Detail::
+Detail:
 
 * When needed (protected): 20 bytes for fadeout
 * When needed (protected): 36 bytes for repair (only if no fadeout occuring)
@@ -36,30 +36,30 @@ Detail::
 Stage: The Hunt
 ---------------
 
-Summary::
+Summary:
 
 * Each frame: 6 bytes (protected) + 0 byte (unprotected)
 * Peak: 36 bytes (protected) + 0 byte (unprotected)
 
-Detail::
+Detail:
 
 * Each frame (protected): 6 bytes for lava's palette swap
 * When needed (protected): 20 bytes for fadeout
 * When needed (protected): 36 bytes for repair
 
-Notes::
+Notes:
 
 * Will each frame do lava's animation, or fadeout, or repair (only one out of the three)
 
 Character: VGSage
 -----------------
 
-Summary::
+Summary:
 
 * Each frame: 0 byte
 * Peak: 79 bytes (protected) + 0 byte (unprotected)
 
-Detail::
+Detail:
 
 * When needed (protected): 20 bytes for fadout/fadein effects of the punch
 * When needed (protected): 36 bytes for Knight's animation

--- a/documentation/rainbow_configuration.rst
+++ b/documentation/rainbow_configuration.rst
@@ -8,11 +8,11 @@ Most Rainbow configuration is done in ``game/logic/mapper_init.asm`` and doesn't
 Memory map
 ----------
 
- * $0000-$07ff: system memory
- * $4800-$4fff: FPGA-RAM high 2 KB (mirrors $7800-$7fff)
- * $6000-$7fff: FPGA-RAM full 8 KB
- * $8000-$bfff: Swapable bank
- * $c000-$ffff: Fixed bank
+* $0000-$07ff: system memory
+* $4800-$4fff: FPGA-RAM high 2 KB (mirrors $7800-$7fff)
+* $6000-$7fff: FPGA-RAM full 8 KB
+* $8000-$bfff: Swapable bank
+* $c000-$ffff: Fixed bank
 
 ROM banking
 -----------

--- a/documentation/stages.rst
+++ b/documentation/stages.rst
@@ -1,58 +1,58 @@
 Constraints on netload routines
 ===============================
 
- * ``A``: output: Can be modified
- * ``X``: output: Can be modified, input: offset of stage's data in current message
- * ``Y``: output: Can be modified
- * ``player_number``: output: Can be modified
+* ``A``: output: Can be modified
+* ``X``: output: Can be modified, input: offset of stage's data in current message
+* ``Y``: output: Can be modified
+* ``player_number``: output: Can be modified
 
 Constraints on fadeout routines
 ===============================
 
-The fadeout routine is called to set a variant of the stage's background palette. There must be five variants::
+The fadeout routine is called to set a variant of the stage's background palette. There must be five variants:
 
- * 0: Full black
- * 1: Darkest visible palette
- * 2: Dark palette
- * 3: Slightly darkened palette
- * 4: Normal palette
+* 0: Full black
+* 1: Darkest visible palette
+* 2: Dark palette
+* 3: Slightly darkened palette
+* 4: Normal palette
 
 The routine must not create a nametable buffer if called during rollback (applying changes on next non-rollback tick is acceptable.)
 
 The stage's special effects must continue to work (ex: palette-swap based animations shall continue while darkened.)
 
-Input::
+Input:
 
- * ``X``: requested fade level
+* ``X``: requested fade level
 
-Output contraints::
+Output contraints:
 
- * ``A``: Can be modified
- * ``X``: Can be modified
- * ``Y``: Can be modified
- * ``player_number``: Cannot be modified
- * ``tmpfields``: Can be modified
- * ``stage_fade_level``: must be set to requested level
+* ``A``: Can be modified
+* ``X``: Can be modified
+* ``Y``: Can be modified
+* ``player_number``: Cannot be modified
+* ``tmpfields``: Can be modified
+* ``stage_fade_level``: must be set to requested level
 
 Sprites allocation in game
 ==========================
 
- * ``0`` -> ``15``: Player A's character animation
- * ``16`` -> ``31``: Player B's character animation
- * ``32`` -> ``41``: Targets in BTT stages // Available for the stage in versus
- * ``42`` -> ``49``: Target-break animation in BTT stage // Character's portrait in versus
- * ``50`` -> ``63``: Particles
+* ``0`` -> ``15``: Player A's character animation
+* ``16`` -> ``31``: Player B's character animation
+* ``32`` -> ``41``: Targets in BTT stages // Available for the stage in versus
+* ``42`` -> ``49``: Target-break animation in BTT stage // Character's portrait in versus
+* ``50`` -> ``63``: Particles
 
 Helpful constants:
 
- * ``INGAME_PLAYER_A_FIRST_SPRITE``
- * ``INGAME_PLAYER_A_LAST_SPRITE``
- * ``INGAME_PLAYER_B_FIRST_SPRITE``
- * ``INGAME_PLAYER_B_LAST_SPRITE``
- * ``INGAME_STAGE_FIRST_SPRITE``
- * ``INGAME_PORTRAIT_FIRST_SPRITE``
- * ``INGAME_PORTRAIT_LAST_SPRITE``
- * ``PARTICLE_FIRST_SPRITE``
+* ``INGAME_PLAYER_A_FIRST_SPRITE``
+* ``INGAME_PLAYER_A_LAST_SPRITE``
+* ``INGAME_PLAYER_B_FIRST_SPRITE``
+* ``INGAME_PLAYER_B_LAST_SPRITE``
+* ``INGAME_STAGE_FIRST_SPRITE``
+* ``INGAME_PORTRAIT_FIRST_SPRITE``
+* ``INGAME_PORTRAIT_LAST_SPRITE``
+* ``PARTICLE_FIRST_SPRITE``
 
 Tile allocation in game
 =======================
@@ -60,49 +60,49 @@ Tile allocation in game
 Sprite tiles
 ------------
 
- * ``0`` -> ``95``: Player A's character graphics
- * ``96`` -> ``191``: Player B's character graphics
- * ``192`` -> ``240``: Available for the stage and game mode
- * ``241`` -> ``247``: Common sprites (particles, out of screen bubble, ...)
- * ``248`` -> ``251``: Player A's portrait
- * ``252`` -> ``255``: Player B's portrait
+* ``0`` -> ``95``: Player A's character graphics
+* ``96`` -> ``191``: Player B's character graphics
+* ``192`` -> ``240``: Available for the stage and game mode
+* ``241`` -> ``247``: Common sprites (particles, out of screen bubble, ...)
+* ``248`` -> ``251``: Player A's portrait
+* ``252`` -> ``255``: Player B's portrait
 
 Beware, deprecated tileset in ``game/banks/chr_data.asm`` still copy stuff in "free" space, leaving ``192`` -> ``218`` blank, and initializing the ``219`` -> ``255`` to values that may be used (particles graphics, oos indicator, ...)
 
 Helpful constants:
 
- * ``CHARACTERS_NUM_TILES_PER_CHAR``
- * ``CHARACTERS_CHARACTER_A_FIRST_TILE``
- * ``CHARACTERS_CHARACTER_B_FIRST_TILE``
- * ``CHARACTERS_CHARACTER_A_TILES_OFFSET``
- * ``CHARACTERS_CHARACTER_B_TILES_OFFSET``
- * ``CHARACTERS_END_TILES``
- * ``CHARACTERS_END_TILES_OFFSET``
- * ``STAGE_FIRST_SPRITE_TILE``
- * ``STAGE_FIRST_SPRITE_TILE_OFFSET``
- * ``STAGE_NUM_SPRITE_TILES``
- * ``INGAME_COMMON_FIRST_SPRITE_TILE``
- * ``INGAME_COMMON_FIRST_SPRITE_TILE_OFFSET``
- * ``INGAME_CHARACTER_A_PORTRAIT_FIRST_SPRITE_TILE``
- * ``INGAME_CHARACTER_B_PORTRAIT_FIRST_SPRITE_TILE``
+* ``CHARACTERS_NUM_TILES_PER_CHAR``
+* ``CHARACTERS_CHARACTER_A_FIRST_TILE``
+* ``CHARACTERS_CHARACTER_B_FIRST_TILE``
+* ``CHARACTERS_CHARACTER_A_TILES_OFFSET``
+* ``CHARACTERS_CHARACTER_B_TILES_OFFSET``
+* ``CHARACTERS_END_TILES``
+* ``CHARACTERS_END_TILES_OFFSET``
+* ``STAGE_FIRST_SPRITE_TILE``
+* ``STAGE_FIRST_SPRITE_TILE_OFFSET``
+* ``STAGE_NUM_SPRITE_TILES``
+* ``INGAME_COMMON_FIRST_SPRITE_TILE``
+* ``INGAME_COMMON_FIRST_SPRITE_TILE_OFFSET``
+* ``INGAME_CHARACTER_A_PORTRAIT_FIRST_SPRITE_TILE``
+* ``INGAME_CHARACTER_B_PORTRAIT_FIRST_SPRITE_TILE``
 
 Background tiles
 ----------------
 
- * ``0`` -> ``207``: Available for the stage and game mode
- * ``208`` -> ``218``: Characters stocks graphics
- * ``219`` -> ``229``: Numeric (plus "%") font for damage metter
- * ``230`` -> ``255``: Alpha font (unused? maybe important for gameover screen?)
+* ``0`` -> ``207``: Available for the stage and game mode
+* ``208`` -> ``218``: Characters stocks graphics
+* ``219`` -> ``229``: Numeric (plus "%") font for damage metter
+* ``230`` -> ``255``: Alpha font (unused? maybe important for gameover screen?)
 
 Helpful constants:
 
- * ``ARCADE_COLON_TILE``
- * ``INGAME_CHARACTER_EMPTY_STOCK_TILE``
+* ``ARCADE_COLON_TILE``
+* ``INGAME_CHARACTER_EMPTY_STOCK_TILE``
 
 Memory allocation
 =================
 
- * ``$80`` -> ``$8f``: Available for the stage
- * ``$05dc`` -> ``$05ff``: Available for stage and game mode
- * ``$0400`` -> ``$0480``: Must begin with stage layout, after that it is freely usable by the stage
- * ``$0600`` -> ``$067f``: Currently unused ingame it seems
+* ``$80`` -> ``$8f``: Available for the stage
+* ``$05dc`` -> ``$05ff``: Available for stage and game mode
+* ``$0400`` -> ``$0480``: Must begin with stage layout, after that it is freely usable by the stage
+* ``$0600`` -> ``$067f``: Currently unused ingame it seems


### PR DESCRIPTION
The rendering of most lists was weird to common rst formatting mistakes.

In some cases it might be on purpose (e.g. `Object types:` in `characters.rst`). Since I wasn't really sure I made all changes that seemed reasonnable. Result can be checked [from the source branch](https://github.com/benoitryder/super-tilt-bro/tree/master/documentation).

If you don't bother and prefer to ignore this PR, no problem. ;)