### PR TITLE
tools: fix multiple python warnings due to regex escaping

### DIFF
--- a/tools/compile-mod.py
+++ b/tools/compile-mod.py
@@ -55,7 +55,7 @@ def find_first_available_bank(game_dir):
 	global FIRST_AVAILABLE_BANK
 	bank_index_template_path = '{}/game/banks.asm'.format(game_dir)
 	with open(bank_index_template_path, 'r') as bank_template_file:
-		re_bank_number = re.compile('^#define CURRENT_BANK_NUMBER FIRST_GAME_BANK\+(?P<num>[$%0-9a-fA-F]+)$')
+		re_bank_number = re.compile(r'^#define CURRENT_BANK_NUMBER FIRST_GAME_BANK\+(?P<num>[$%0-9a-fA-F]+)$')
 		current_bank_number = None
 		for line_num, line in enumerate(bank_template_file):
 			if line.startswith(';; mod banks'):

--- a/tools/flame/routines_addresses.py
+++ b/tools/flame/routines_addresses.py
@@ -20,8 +20,8 @@ if len(sys.argv) > 1:
 #
 
 re_label = re.compile('^(?P<label>[a-z0-9_-]+)( +)$')
-re_open_scope = re.compile('[ \t]+\\.\\(.*')
-re_close_scope = re.compile('[ \t]+\\.\\).*')
+re_open_scope = re.compile(r'[ \t]+\.\(.*')
+re_close_scope = re.compile(r'[ \t]+\.\).*')
 
 routines = []
 

--- a/tools/ftm-to-stb/asm-sample-count-ticks.py
+++ b/tools/ftm-to-stb/asm-sample-count-ticks.py
@@ -12,12 +12,12 @@ import re
 
 DEFAULT_NOTE_DUR = 5
 
-re_play_timed_freq = re.compile('PLAY_TIMED_FREQ\([0-9]+,(?P<dur>[0-9]+)\)')
-re_play_note = re.compile('PLAY_NOTE\((?P<dir>[0-9]+),(?P<mul>[0-9]+),[0-9]+\)')
-re_play_timed_note = re.compile('PLAY_TIMED_NOTE\((?P<dur>[0-9]+),0-9]+\)')
-re_wait = re.compile('WAIT\((?P<dur>[0-9]+)\)')
-re_long_wait = re.compile('LONG_WAIT\((?P<dur>[0-9]+)\)')
-re_halt = re.compile('HALT\((?P<dur>[0-9]+)\)')
+re_play_timed_freq = re.compile(r'PLAY_TIMED_FREQ\([0-9]+,(?P<dur>[0-9]+)\)')
+re_play_note = re.compile(r'PLAY_NOTE\((?P<dir>[0-9]+),(?P<mul>[0-9]+),[0-9]+\)')
+re_play_timed_note = re.compile(r'PLAY_TIMED_NOTE\((?P<dur>[0-9]+),0-9]+\)')
+re_wait = re.compile(r'WAIT\((?P<dur>[0-9]+)\)')
+re_long_wait = re.compile(r'LONG_WAIT\((?P<dur>[0-9]+)\)')
+re_halt = re.compile(r'HALT\((?P<dur>[0-9]+)\)')
 
 re_sample_end = re.compile('SAMPLE_END')
 

--- a/tools/stblib/asmformat/animations.py
+++ b/tools/stblib/asmformat/animations.py
@@ -106,10 +106,10 @@ def frame_bin_size(frame):
 	)
 
 RE_ANIM_LABEL = re.compile('(?P<name>([a-z]+_)?anim_[a-z_]+):')
-RE_ANIM_FRAME_BEGIN = re.compile('ANIM_FRAME_BEGIN\((?P<duration>[$%0-9a-fA-F]+)\)')
-RE_ANIM_HURTBOX = re.compile('ANIM_HURTBOX\((?P<left>[$%0-9a-fA-F]+),( *)(?P<right>[$%0-9a-fA-F]+),( *)(?P<top>[$%0-9a-fA-F]+),( *)(?P<bottom>[$%0-9a-fA-F]+)\)')
-RE_ANIM_HITBOX = re.compile('ANIM_HITBOX\((?P<enabled>[$%0-9a-fA-F]+),( *)(?P<damages>[$%0-9a-fA-F]+),( *)(?P<base_h>[$%0-9a-fA-F]+),( *)(?P<base_v>[$%0-9a-fA-F]+),( *)(?P<force_h>[$%0-9a-fA-F]+),( *)(?P<force_v>[$%0-9a-fA-F]+),( *)(?P<left>[$%0-9a-fA-F]+),( *)(?P<right>[$%0-9a-fA-F]+),( *)(?P<top>[$%0-9a-fA-F]+),( *)(?P<bottom>[$%0-9a-fA-F]+)\)')
-RE_ANIM_SPRITE = re.compile('ANIM_SPRITE(?P<type>_FOREGROUND)?\((?P<y>[$%0-9a-fA-F]+), (?P<tile>[$%0-9a-fA-Z_]+), (?P<attr>[$%0-9a-fA-F]+), (?P<x>[$%0-9a-fA-F]+)\)')
+RE_ANIM_FRAME_BEGIN = re.compile(r'ANIM_FRAME_BEGIN\((?P<duration>[$%0-9a-fA-F]+)\)')
+RE_ANIM_HURTBOX = re.compile(r'ANIM_HURTBOX\((?P<left>[$%0-9a-fA-F]+),( *)(?P<right>[$%0-9a-fA-F]+),( *)(?P<top>[$%0-9a-fA-F]+),( *)(?P<bottom>[$%0-9a-fA-F]+)\)')
+RE_ANIM_HITBOX = re.compile(r'ANIM_HITBOX\((?P<enabled>[$%0-9a-fA-F]+),( *)(?P<damages>[$%0-9a-fA-F]+),( *)(?P<base_h>[$%0-9a-fA-F]+),( *)(?P<base_v>[$%0-9a-fA-F]+),( *)(?P<force_h>[$%0-9a-fA-F]+),( *)(?P<force_v>[$%0-9a-fA-F]+),( *)(?P<left>[$%0-9a-fA-F]+),( *)(?P<right>[$%0-9a-fA-F]+),( *)(?P<top>[$%0-9a-fA-F]+),( *)(?P<bottom>[$%0-9a-fA-F]+)\)')
+RE_ANIM_SPRITE = re.compile(r'ANIM_SPRITE(?P<type>_FOREGROUND)?\((?P<y>[$%0-9a-fA-F]+), (?P<tile>[$%0-9a-fA-Z_]+), (?P<attr>[$%0-9a-fA-F]+), (?P<x>[$%0-9a-fA-F]+)\)')
 RE_ANIM_END = re.compile('ANIM_ANIMATION_END')
 
 def parse_animations(anim_file):

--- a/tools/stblib/tiles.py
+++ b/tools/stblib/tiles.py
@@ -2,8 +2,8 @@
 from stblib import ensure
 import re
 
-tile_byte = '(%|\$)(([01][01][01][01][01][01][01][01])|([0-9a-f][0-9a-f]))'
-re_tileline = re.compile('\.byt %s, %s, %s, %s, %s, %s, %s, %s' % ((tile_byte,)*8))
+tile_byte = r'(%|\$)(([01][01][01][01][01][01][01][01])|([0-9a-f][0-9a-f]))'
+re_tileline = re.compile(r'\.byt %s, %s, %s, %s, %s, %s, %s, %s' % ((tile_byte,)*8))
 
 class Tile:
 	def __init__(self, representation = None):


### PR DESCRIPTION
Same idea as 4fa7f30f1898d8abda1f8db3f7935eff67fc1ff4

I grepped all `re.compile()` with backslashes.